### PR TITLE
Add write-ups for the linking and transfer flows

### DIFF
--- a/docs/design/linking.md
+++ b/docs/design/linking.md
@@ -41,10 +41,10 @@ the events will be notified and could proceed to do necessary operations, such a
 requests to Mojaloop. Likewise, when Mojaloop makes a callback to the server, it can update the
 data in Firebase, which will notify the mobile app for the relevant user.
 
-The diagram below shows how both the server and mobile app could start listening to the transaction
-documents. For the server, it will listen to all of the transaction documents from all users.
-Meanwhile, each user is only allowed to listen to their transactions. Firebase rules will also help
-to prevent a user from looking at other users' transactions.
+The diagram below shows how both the server and mobile app could start listening to the consent
+documents. For the server, it will listen to all of the consent documents from all users.
+Meanwhile, each user is only allowed to listen to their consents. Firebase rules will also help
+to prevent a user from looking at other users' consents.
 
 ![Create Listener](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/linking/1-create-listener.puml)
 

--- a/docs/design/linking.md
+++ b/docs/design/linking.md
@@ -1,5 +1,14 @@
 # Linking
 
+Linking is one of the core components for the PISP server to be able to integrate with Mojaloop.
+Before a PISP could initiate a transaction on behalf of its user, a trust must be established
+between the user, FSP, and PISP itself. This is where the linking process plays an important role.
+After performing the necessary steps, the FSP should recognize that the user has given their
+consent to the PISP.
+
+The following are the different phases of operations that need to be performed to establish the
+trust and revoke it if the user does not want a PISP to initiate transfers on behalf of them anymore:
+
 * [1. Create Listener](#1-create-listener)
 * [2. Linking](#2-linking)
   * [2.1. Pre-linking](#2-1-pre-linking)
@@ -16,56 +25,129 @@
   * [2.8. Sign Challenge](#2-8-sign-challenge)
 * [3. Unlinking](#3-unlinking)
 
+There are 5 main participants that will be involved throughout the linking flow:
+- User that interacts with the PISP app
+- PISP app that displays beautiful UI to the user and abstracts out all of the processes going on behind the scene.
+- Firebase that bridges the communication and data synchronization between the app and server.
+- PISP server that implements the communication with Mojaloop using its SDK.
+- Mojaloop switch which will route the requests from PISP server to the correct services in Mojaloop.
+
 ## 1. Create Listener
+
+Before everything else starts, both the PISP demo server and the app need to open a
+communication with Firebase, which is responsible for handling the data synchronization.
+Whenever the mobile app performs an update in Firebase, the server that is listening to all of 
+the events will be notified and could proceed to do necessary operations, such as making HTTP
+requests to Mojaloop. Likewise, when Mojaloop makes a callback to the server, it can update the
+data in Firebase, which will notify the mobile app for the relevant user.
+
+The diagram below shows how both the server and mobile app could start listening to the transaction
+documents. For the server, it will listen to all of the transaction documents from all users.
+Meanwhile, each user is only allowed to listen to their transactions. Firebase rules will also help
+to prevent a user from looking at other users' transactions.
 
 ![Create Listener](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/linking/1-create-listener.puml)
 
 ## 2. Linking
 
+Throughout all of the linking phases, the PISP aims to be able to get the consent from the
+user to initiate transfers on behalf of them.
+
 ### 2.1. Pre-linking
+
+In this phase, the PISP tries to get the list of FSPs that their user could link using Mojaloop.
+The PISP server will regularly try to fetch the list of FSPs and update the data in Firebase.
+In the following sequence diagram, the server will do the operations daily. It is because we expect
+the list of FSPs not to change very often, and hence we could cache it in Firebase to reduce the
+number of requests that we may need to make to Mojaloop.
 
 ![Pre-linking](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/linking/2-1-pre-linking.puml)
 
 ### 2.2. Discovery
 
+In this phase, the user will be prompted to enter an opaque identifier to the mobile app.
+The purpose is to look up the information about the accounts available in Mojaloop for the user
+to connect. However, the opaque identifier is special in Mojaloop and cannot be used to initiate transactions.
+Hence, the result of the party lookup will contain a valid party identifier to make future transactions.
+More details about this could be found in the discussion thread [here](https://github.com/mojaloop/pisp/issues/45).
+
 ![Discovery](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/linking/2-2-discovery.puml)
 
 ### 2.3. Consent Request
+
+In this phase, the user has decided to connect some selected accounts with their PISP account.
+Hence, the app will try to inform the server of the selected accounts, which could then be
+processed further by initiating a consent request to Mojaloop.
 
 ![Consent Request](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/linking/2-3-consent-request.puml)
 
 ### 2.4. Authentication Prompt
 
+Upon receiving the consent request, the FSP will try to ask the PISP to prove their relation with
+the user. In this phase, there are currently two possible ways of doing this: Web and OTP.
+
 #### 2.4.1. Web
+
+In this case, the PISP will receive an authentication URI from the FSP. It is also supposed to redirect user to that URI.
 
 ![Authentication Prompt (Web)](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/linking/2-4-1-authentication-prompt-web.puml)
 
 #### 2.4.2. OTP
 
+In this case, the PISP will not receive an authentication URI from the FSP. The user will be prompted to enter the OTP.
+
 ![Authentication Prompt (OTP)](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/linking/2-4-2-authentication-prompt-otp.puml)
 
 ### 2.5. Authentication
 
+In this phase, the PISP app should prove that the user trusts it. The way to do that is for the
+user to pass in the authentication token. It could be in the form of any secret token or OTP to
+the PISP app. The application will then pass the information to the server. The server will request
+Mojaloop to give the authentication value. If the value is valid, then the FSP will trust the PISP
+as they only gave the secret to the user previously and the fact that the PISP has it means that
+the user trusts the PISP by giving their authentication value.
+
 #### 2.5.1. Web
+
+The web authentication page of the FSP will redirect to the PISP app using a deep link. The secret
+authentication value is also expected to be passed on upon redirection. The secret will then be passed
+to the server and afterward to Mojaloop.
 
 ![Authentication (Web)](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/linking/2-5-1-authentication-web.puml)
 
 #### 2.5.2. OTP
 
+The user is expected to key in their OTP code which should be sent by the FSP.
+
 ![Authentication (OTP)](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/linking/2-5-2-authentication-otp.puml)
 
 ### 2.6. Grant Consent
+
+In this phase, Mojaloop will send a callback to the server notifying that the consent has been granted.
+The server could decide to pass on the information to the app if it wants to display or update the UI.
+However, note that the server is also expected to request a challenge for FIDO registration in Mojaloop
+immediately.
 
 ![Grant Consent](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/linking/2-6-grant-consent.puml)
 
 ### 2.7. Request Challenge
 
+The server requests a challenge from Mojaloop for FIDO registration. Mojaloop will send a callback that
+contains a challenge that needs to be digitally signed for the registration.
+
 ![Request Challenge](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/linking/2-7-request-challenge.puml)
 
 ### 2.8. Sign Challenge
 
+The app is expected to use the FIDO library to digitally sign the challenge using the private key that
+it generates. The signature and public key will then be sent to the Server and afterward Mojaloop.
+If the process is successful, the server will receive a callback from Mojaloop saying that the consent
+is active by that point.
+
 ![Sign Challenge](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/linking/2-8-sign-challenge.puml)
 
 ## 3. Unlinking
+
+This phase is intended to handle the case when the user wants to revoke the consent that they had given to the PISP. 
 
 ![Unlinking](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/linking/3-unlinking.puml)

--- a/docs/design/transfer.md
+++ b/docs/design/transfer.md
@@ -1,5 +1,9 @@
 # Transfer
 
+Transfer is one of the core components for the PISP server when integrating with Mojaloop. This flow is used by a PISP to initiate a transaction on behalf of its user. Some of the phases below rely on the trust that has been established using the [linking flow](./linking.md). After performing the necessary steps, the money will be moved from the payer's account to the payee's account without the need for the user to interact directly with their FSP.
+
+The following are the different phases of operations that need to be performed to perform a transfer:
+
 1. [Create Listener](#1-create-listener)
 2. [Create Transaction](#2-create-transaction)
 3. [Confirm Payee](#3-confirm-payee)
@@ -7,26 +11,57 @@
 5. [Authorize Transaction](#4-authorize-transaction)
 6. [Transaction Feedback](#5-transaction-feedback)
 
+There are 5 main participants that will be involved throughout the linking flow:
+- User that interacts with the PISP app
+- PISP app that displays beautiful UI to the user and abstracts out all of the processes going on behind the scene.
+- Firebase that bridges the communication and data synchronization between the app and server.
+- PISP server that implements the communication with Mojaloop using its SDK.
+- Mojaloop switch which will route the requests from PISP server to the correct services in Mojaloop.
+
 ## 1. Create Listener
+
+Before everything else starts, both the PISP demo server and the app need to open a
+communication with Firebase, which is responsible for handling the data synchronization.
+Whenever the mobile app performs an update in Firebase, the server that is listening to all of 
+the events will be notified and could proceed to do necessary operations, such as making HTTP
+requests to Mojaloop. Likewise, when Mojaloop makes a callback to the server, it can update the
+data in Firebase, which will notify the mobile app for the relevant user.
+
+The diagram below shows how both the server and mobile app could start listening to the transaction
+documents. For the server, it will listen to all of the transaction documents from all users.
+Meanwhile, each user is only allowed to listen to their transactions. Firebase rules will also help
+to prevent a user from looking at other users' transactions.
 
 ![Create Listener](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/transfer/01-create-listener.puml)
 
 ## 2. Create Transaction
 
+In this phase, the PISP creates a new transaction document and provides some information about the payee. Currently, the identifier that should be used for the PISP demo server is a phone number. However, this may change when we would like to support more identifiers, such as a national identification number. 
+
+The PISP server is expected to perform a party lookup to Mojaloop to get more information about the payee, such as name and FSP identifier. That information will then be displayed to the user to check whether they would like to send money to the correct party.
+
 ![Create Transaction](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/transfer/02-create-transaction.puml)
 
 ## 3. Confirm Payee
+
+In this phase, the user is expected to confirm that the payee is correct and provide more detailed information such as the transaction amount and account that they would like to send the money from.
 
 ![Confirm Transaction](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/transfer/03-confirm-payee.puml)
 
 ## 4. Authorization Prompt
 
+In this phase, Mojaloop has received the transaction request and asks the PISP to provide authorization from the user. It will be based on the consent that has been established from the linking process.
+
 ![Authorization Prompt](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/transfer/04-authorization-prompt.puml)
 
 ## 5. Authorize Transaction
 
+Here the PISP tries to prove to the FSP that it initiates the transaction upon a request by the user. The app will try to call the FIDO library to have the transaction quote digitally signed using the private key generated in the linking process.
+
 ![Authorize Transaction](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/transfer/05-authorize-transaction.puml)
 
 ## 6. Transaction Feedback
+
+Once Mojaloop verifies that the authorization provided was indeed valid based on the established trust, a transfer will be processed in the RTP network. A request containing the transfer status will be forwarded to the PISP server to notify whether the transaction is successful. In the happy path, it will contain information saying that the transaction has been committed. The PISP app is then expected to notify the user about the transaction status.
 
 ![Transaction Feedback](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/mojaloop/pisp-demo-server/master/docs/assets/diagrams/transfer/06-transaction-feedback.puml)


### PR DESCRIPTION
This PR adds some more explanation to the documentation for both the transfer and linking flows as there were only sequence diagrams. Hopefully, this will improve the readability for people who want to discover more about how both important phases to connect with Mojaloop.