### PR TITLE
feat(accounts): create accounts after consent creation

### DIFF
--- a/src/models/demoAccount.ts
+++ b/src/models/demoAccount.ts
@@ -1,0 +1,32 @@
+
+
+// DemoAccount is a representation of a linked 
+// account, internal to the PISP-Demo-Server
+// A demo account is created for _each_ linked
+// selection in a consent
+export interface DemoAccount {
+  /**
+   * The user friendly name of the account
+   */
+  alias: string,
+
+  fspInfo: {
+    id: string,
+    name: string,
+  }
+  
+  /**
+   * The id of the account
+   */
+  sourceAccountId: string,
+
+  /**
+   * The id of the user who created the link
+   */
+  userId: string,
+
+  /**
+   * internal Id of the DemoAccount
+   */
+  id?: string,
+}

--- a/src/models/demoAccount.ts
+++ b/src/models/demoAccount.ts
@@ -1,6 +1,4 @@
-
-
-// DemoAccount is a representation of a linked 
+// DemoAccount is a representation of a linked
 // account, internal to the PISP-Demo-Server
 // A demo account is created for _each_ linked
 // selection in a consent
@@ -8,25 +6,25 @@ export interface DemoAccount {
   /**
    * The user friendly name of the account
    */
-  alias: string,
+  alias: string
 
   fspInfo: {
-    id: string,
-    name: string,
+    id: string
+    name: string
   }
-  
+
   /**
    * The id of the account
    */
-  sourceAccountId: string,
+  sourceAccountId: string
 
   /**
    * The id of the user who created the link
    */
-  userId: string,
+  userId: string
 
   /**
    * internal Id of the DemoAccount
    */
-  id?: string,
+  id?: string
 }

--- a/src/repositories/account.ts
+++ b/src/repositories/account.ts
@@ -1,14 +1,11 @@
 import firebase from '~/lib/firebase'
 import { DemoAccount } from '~/models/demoAccount'
 
-
 export interface IAccountRepository {
-
   insert(data: DemoAccount): Promise<string>
 }
 
 export class FirebaseAccountRepository implements IAccountRepository {
-
   // TD: Lewis hacky to get some tests working
   async insert(data: DemoAccount): Promise<string> {
     const ref = await firebase.firestore().collection('accounts').doc()

--- a/src/repositories/account.ts
+++ b/src/repositories/account.ts
@@ -1,0 +1,21 @@
+import firebase from '~/lib/firebase'
+import { DemoAccount } from '~/models/demoAccount'
+
+
+export interface IAccountRepository {
+
+  insert(data: DemoAccount): Promise<string>
+}
+
+export class FirebaseAccountRepository implements IAccountRepository {
+
+  // TD: Lewis hacky to get some tests working
+  async insert(data: DemoAccount): Promise<string> {
+    const ref = await firebase.firestore().collection('accounts').doc()
+    // Make sure we set the id correctly
+    data.id = ref.id
+    await ref.set(data)
+    return (data.id as unknown) as string
+  }
+}
+export const accountRepository: IAccountRepository = new FirebaseAccountRepository()

--- a/src/shared/ml-thirdparty-simulator/factories/party.ts
+++ b/src/shared/ml-thirdparty-simulator/factories/party.ts
@@ -45,8 +45,8 @@ export class PartyFactory {
    */
   public static createPutAccountsRequest(_id: string): Array<Account> {
     const accounts: Account[] = [ // hardcode two currencies
-      { accountNickname: 'ChXXXXXXXXXXunt', id: v4(), currency: Currency.USD},
-      { accountNickname: 'TraXXXXXXXXXXunt', id: v4(), currency: Currency.USD}
+      { accountNickname: 'Chequing Account', id: v4(), currency: Currency.USD},
+      { accountNickname: 'Transaction Account', id: v4(), currency: Currency.USD}
     ]
 
     return accounts


### PR DESCRIPTION
Creates some sample accounts after the consent is finalized. This make the app a little bit nicer to use.